### PR TITLE
Fixes set_data_columns to avoid an exception

### DIFF
--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 from scipy.spatial import Voronoi
 from tyssue.utils import utils
 from tyssue import Sheet, SheetGeometry
@@ -31,6 +32,27 @@ def test_spec_updater():
     utils.spec_updater(specs, new_specs)
     print(specs)
     assert specs['face']['geometry'] == new_specs['face']['geometry']
+
+
+def test_set_data_columns():
+    dsets, _ = three_faces_sheet()
+    specs = {"cell": {'nope': 0},
+             "vert": {'new': 100},
+             "edge": {'new': 'r'}}
+    with pytest.warns(UserWarning):
+        utils.set_data_columns(dsets, specs, reset=False)
+        assert dsets['vert']['new'].loc[0] == 100
+        assert dsets['edge']['new'].loc[0] == 'r'
+
+    specs = {"vert": {'new': 10},
+             "edge": {'new': 'v'}}
+    utils.set_data_columns(dsets, specs, reset=False)
+    assert dsets['edge']['new'].loc[0] == 'r'
+    assert dsets['vert']['new'].loc[0] == 100
+
+    utils.set_data_columns(dsets, specs, reset=True)
+    assert dsets['vert']['new'].loc[0] == 10
+    assert dsets['edge']['new'].loc[0] == 'v'
 
 
 def test_data_at_opposite():

--- a/tyssue/utils/utils.py
+++ b/tyssue/utils/utils.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 import logging
 import pandas as pd
@@ -59,20 +60,39 @@ def spec_updater(specs, new):
 
 
 def set_data_columns(datasets, specs, reset=False):
+    """Sets the columns of the dataframes in the datasets dictionnary to
+    the uniform values in the specs sub-dictionnaries.
 
-    if reset:
-        logger.warning('Reseting datasets values with new specs')
+    Parameters
+    ----------
+    datasets : dict of dataframes
+    specs : dict of dicts
+    reset : bool, default False
+
+    For each key in specs, the value is a dictionnary whose
+    keys are column names for the corresponding dataframe in
+    datasets. If there is no such column in the dataframe,
+    it is created. If the columns allready exists and  reset is `True`,
+    the new value is used.
+    """
+
 
     for name, spec in specs.items():
         if not len(spec):
             continue
         if 'setting' in name:
             continue
-        df = datasets[name]
+        df = datasets.get(name)
+        if df is None:
+            warnings.warn(f"There is no {name} dataset, so the {name}"
+                          " spec have no effect.")
+            continue
         for col, default in spec.items():
+            if col in df.columns and reset:
+                logger.warning('Reseting column %s of the %s'
+                               ' dataset with new specs', [col, name])
             if col not in df.columns or reset:
                 df[col] = default
-
 
 def data_at_opposite(sheet, edge_data, free_value=None):
     """


### PR DESCRIPTION
`set_data_columns`, used in `Epithelium.update_specs` would fail with a `KeyError` if keys in specs are not in the object datasets. This is now caught and a simple warning is raised.