### PR TITLE
adds a merge_border_edges function

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 matplotlib
-pandas
+pandas >= 0.24
 pytables
 jupyter
 notebook

--- a/tests/topology/test_topology.py
+++ b/tests/topology/test_topology.py
@@ -132,3 +132,4 @@ def test_merge_border_edges():
         .min()
         == -1
     )
+    assert not set(sheet.vert_df.index).difference(sheet.edge_df.srce)

--- a/tests/topology/test_topology.py
+++ b/tests/topology/test_topology.py
@@ -119,3 +119,16 @@ def test_close_face():
 
     close_face(sheet, face)
     assert sheet.Ne == Ne
+
+
+def test_merge_border_edges():
+    sheet = Sheet.planar_sheet_3d("sheet", 5, 6, 1, 1)
+    sheet.get_opposite()
+    sheet.sanitize(trim_borders=True)
+    assert (
+        sheet.edge_df[sheet.edge_df["opposite"] < 0]
+        .groupby("face")["opposite"]
+        .sum()
+        .min()
+        == -1
+    )

--- a/tyssue/core/objects.py
+++ b/tyssue/core/objects.py
@@ -595,15 +595,21 @@ class Epithelium:
         is_valid = self.get_valid()
         return ~is_valid
 
-    def sanitize(self):
+    def sanitize(self, trim_borders=False):
         """Removes invalid faces and associated vertices
+
+        If trim_borders is True (defaults to False), there will be a single
+        border edge per border face.
         """
         invalid_edges = self.get_invalid()
-        self.remove(invalid_edges)
+        self.remove(invalid_edges, trim_borders)
 
-    def remove(self, edge_out):
+    def remove(self, edge_out, trim_borders=False):
         """Remove the edges indexed by `edge_out` associated with all
         the cells and faces containing those edges
+
+        If trim_borders is True (defaults to False), there will be a single
+        border edge per border face.
         """
         top_level = self.element_names[-1]
         log.info("Removing cells at the %s level", top_level)
@@ -615,7 +621,7 @@ class Epithelium:
             raise ValueError("sanitize would delete the whole epithlium")
 
         fto_rm.sort()
-        log.info("%d %s level elements will be removed", (len(fto_rm), top_level))
+        log.info("%d %s level elements will be removed", len(fto_rm), top_level)
 
         edge_df_ = (
             self.edge_df.set_index(top_level, append=True).swaplevel(0, 1).sort_index()
@@ -634,6 +640,10 @@ class Epithelium:
             self.cell_df = self.cell_df.drop(fto_rm)
         self.reset_index()
         self.reset_topo()
+        if trim_borders:
+            from ..topology.base_topology import merge_border_edges
+
+            merge_border_edges(self)
 
     def cut_out(self, bbox, coords=None):
         """Returns the index of edges with at least one vertex outside of the bounding box

--- a/tyssue/core/objects.py
+++ b/tyssue/core/objects.py
@@ -602,6 +602,10 @@ class Epithelium:
         border edge per border face.
         """
         invalid_edges = self.get_invalid()
+        if not len(invalid_edges) and trim_borders:
+            from ..topology.base_topology import merge_border_edges
+
+            merge_border_edges(self)
         self.remove(invalid_edges, trim_borders)
 
     def remove(self, edge_out, trim_borders=False):
@@ -681,6 +685,9 @@ class Epithelium:
         """
         log.debug("reseting index for %s", self.identifier)
         self.topo_changed = True
+
+        # remove disconnected vertices
+        self.vert_df = self.vert_df.reindex(set(self.edge_df.srce))
 
         new_vertidx = pd.Series(
             np.arange(self.vert_df.shape[0]), index=self.vert_df.index

--- a/tyssue/core/sheet.py
+++ b/tyssue/core/sheet.py
@@ -344,9 +344,9 @@ def get_opposite(edge_df):
     flipped.names = ["srce", "trgt"]
     try:
         opposite = st_indexed.reindex(flipped)["edge"].values
-    # except ValueError: # see https://github.com/pandas-dev/pandas/issues/21770, will be fixed in
+    # see https://github.com/pandas-dev/pandas/issues/21770, will be fixed in
     # pandas 0.24
-    except Exception:
+    except ValueError:
         dup = flipped.duplicated()
         warnings.warn(
             "Duplicated (`srce`, `trgt`) values in edge_df, maybe sanitize your input"

--- a/tyssue/topology/base_topology.py
+++ b/tyssue/topology/base_topology.py
@@ -162,3 +162,26 @@ def condition_4ii(eptm):
     """
     n_common = get_num_common_edges(eptm)
     return list(n_common[n_common >= 2].index)
+
+
+def merge_border_edges(sheet):
+    """Merge edges at the border of a sheet such that no vertex has only
+    an on-going and an out-going edge.
+
+    """
+
+    single_trgt = sheet.edge_df[
+        sheet.upcast_trgt(sheet.edge_df.groupby("trgt").apply(len) == 1)
+    ]
+    faces = set(single_trgt["face"])
+    single_srce = sheet.edge_df[
+        sheet.upcast_srce(sheet.edge_df.groupby("srce").apply(len) == 1)
+    ]
+    sheet.edge_df.drop(single_srce.index, inplace=True)
+    sheet.edge_df.drop(
+        set(single_trgt.index).difference(single_srce.index), inplace=True
+    )
+    for face in faces:
+        close_face(sheet, face)
+    sheet.reset_index()
+    sheet.reset_topo()


### PR DESCRIPTION
The `merge_border_edges` function trims the border edges so that no vertex belong to a single border face.
Also adds a `trim_border` option to the `cut_out` and `sanitize` `Epithelium` methods.