### PR TITLE
Enables deep copy of the specs

### DIFF
--- a/tests/core/test_objects.py
+++ b/tests/core/test_objects.py
@@ -230,8 +230,11 @@ def test_eptm_copy():
     eptm_copy = eptm.copy()
     assert eptm_copy.identifier == eptm.identifier + "_copy"
     assert set(eptm_copy.datasets.keys()).issuperset(eptm.datasets.keys())
+    eptm.settings["deepcopy"] = False
     eptm_deepcopy = eptm.copy(deep_copy=True)
+    eptm_deepcopy.settings["deepcopy"] = True
     assert eptm_deepcopy is not None
+    assert eptm.settings["deepcopy"] is not eptm_deepcopy.settings["deepcopy"]
 
 
 def test_settings_getter_setter():

--- a/tyssue/core/objects.py
+++ b/tyssue/core/objects.py
@@ -185,26 +185,20 @@ class Epithelium:
 
         Parameters
         ----------
-        deep_copy: bool, default True
+        deep_copy : bool, default True
             if True, use a copy of the original object's datasets
             to create the new object. If False, datasets are not copied
         """
         if deep_copy:
-            datasets = {element: df.copy()
-                        for element, df in self.datasets.items()}
-            specs = {key: value.copy()
-                     for key, value in self.specs.items()}
+            datasets = {element: df.copy() for element, df in self.datasets.items()}
+            specs = {key: value.copy() for key, value in self.specs.items()}
         else:  # pragma: no cover
-            log.info(
-                "New epithelium object from {}"
-                " without deep copy".format(
-                    self.identifier))
+            log.info("New epithelium object from %s without deep copy", self.identifier)
             datasets = self.datasets
             specs = self.specs
 
-        identifier = self.identifier+'_copy'
-        new = type(self)(identifier, datasets,
-                         specs=specs, coords=self.coords)
+        identifier = self.identifier + '_copy'
+        new = type(self)(identifier, datasets, specs=specs, coords=self.coords)
         return new
 
     def backup(self):

--- a/tyssue/core/objects.py
+++ b/tyssue/core/objects.py
@@ -185,18 +185,26 @@ class Epithelium:
 
         Parameters
         ----------
-        deep_copy : bool, default True
+        deep_copy: bool, default True
             if True, use a copy of the original object's datasets
             to create the new object. If False, datasets are not copied
         """
         if deep_copy:
-            datasets = {element: df.copy() for element, df in self.datasets.items()}
+            datasets = {element: df.copy()
+                        for element, df in self.datasets.items()}
+            specs = {key: value.copy()
+                     for key, value in self.specs.items()}
         else:  # pragma: no cover
-            log.info("New epithelium object from %s without deep copy", self.identifier)
+            log.info(
+                "New epithelium object from {}"
+                " without deep copy".format(
+                    self.identifier))
             datasets = self.datasets
+            specs = self.specs
 
-        identifier = self.identifier + "_copy"
-        new = type(self)(identifier, datasets, specs=self.specs, coords=self.coords)
+        identifier = self.identifier+'_copy'
+        new = type(self)(identifier, datasets,
+                         specs=specs, coords=self.coords)
         return new
 
     def backup(self):

--- a/tyssue/core/objects.py
+++ b/tyssue/core/objects.py
@@ -191,7 +191,10 @@ class Epithelium:
         """
         if deep_copy:
             datasets = {element: df.copy() for element, df in self.datasets.items()}
-            specs = {key: value.copy() for key, value in self.specs.items()}
+            specs = self.specs.copy()
+            for key, value in self.specs.items():
+                if type(value) in (pd.core.frame.DataFrame, dict):
+                    specs[key] = value.copy()
         else:  # pragma: no cover
             log.info("New epithelium object from %s without deep copy", self.identifier)
             datasets = self.datasets

--- a/tyssue/core/objects.py
+++ b/tyssue/core/objects.py
@@ -6,6 +6,7 @@ import logging
 from collections import deque
 import numpy as np
 import pandas as pd
+from copy import deepcopy
 from ..utils.utils import set_data_columns, spec_updater
 
 log = logging.getLogger(name=__name__)
@@ -191,10 +192,7 @@ class Epithelium:
         """
         if deep_copy:
             datasets = {element: df.copy() for element, df in self.datasets.items()}
-            specs = self.specs.copy()
-            for key, value in self.specs.items():
-                if type(value) in (pd.core.frame.DataFrame, dict):
-                    specs[key] = value.copy()
+            specs = deepcopy(self.specs)
         else:  # pragma: no cover
             log.info("New epithelium object from %s without deep copy", self.identifier)
             datasets = self.datasets

--- a/tyssue/core/objects.py
+++ b/tyssue/core/objects.py
@@ -197,7 +197,7 @@ class Epithelium:
             datasets = self.datasets
             specs = self.specs
 
-        identifier = self.identifier + '_copy'
+        identifier = self.identifier + "_copy"
         new = type(self)(identifier, datasets, specs=specs, coords=self.coords)
         return new
 


### PR DESCRIPTION
This PR solves issue #132 about specs not being deep-copied when using the copy() method of a Sheet object with default argument deep_copy=True. 