### PR TITLE
Attempt to fix HDF5ExtError

### DIFF
--- a/doc/bibliography/tyssue.bib
+++ b/doc/bibliography/tyssue.bib
@@ -3451,5 +3451,39 @@ IMPORTANCE Current microfluidic techniques are powerful to study bacteria and de
   author = {Bi, Dapeng and Lopez, J. H. and Schwarz, J. M. and Manning, M. Lisa}
 }
 
+@article{Lardennoisactinbasedviscoplasticlock2019,
+  langid = {english},
+  title = {An Actin-Based Viscoplastic Lock Ensures Progressive Body-Axis Elongation},
+  issn = {1476-4687},
+  url = {https://www.nature.com/articles/s41586-019-1509-4},
+  doi = {10.1038/s41586-019-1509-4},
+  abstract = {Molecular analysis and mathematical modelling are combined to identify a network of factors that account for viscoplastic deformation in elongation of Caenorhabditis elegans during embryonic development.},
+  journaltitle = {Nature},
+  shortjournal = {Nature},
+  urldate = {2019-08-30},
+  date = {2019-08-28},
+  pages = {1-5},
+  author = {Lardennois, Alicia and P\'asti, Gabriella and Ferraro, Teresa and Llense, Flora and Mahou, Pierre and Pontabry, Julien and Rodriguez, David and Kim, Samantha and Ono, Shoichiro and Beaurepaire, Emmanuel and Gally, Christelle and Labouesse, Michel},
+  file = {/home/guillaume/.mozilla/firefox/14u1jeb7.default-1392277802592/zotero/storage/LM8X8TZP/s41586-019-1509-4.html}
+}
+
+@article{ChenExtracellularmatrixstiffness2019,
+  langid = {english},
+  title = {Extracellular Matrix Stiffness Cues Junctional Remodeling for {{3D}} Tissue Elongation},
+  volume = {10},
+  issn = {2041-1723},
+  url = {https://www.nature.com/articles/s41467-019-10874-x},
+  doi = {10.1038/s41467-019-10874-x},
+  abstract = {The extracellular matrix can shape developing organs, but how external forces direct intercellular morphogenesis is unclear. Here, the authors use 3D imaging to show that elongation of the Drosophila egg chamber involves polarized cell reorientation signalled by changes in stiffness of the surrounding extracellular matrix.},
+  number = {1},
+  journaltitle = {Nature Communications},
+  shortjournal = {Nat Commun},
+  urldate = {2019-08-30},
+  date = {2019-07-26},
+  pages = {1-15},
+  author = {Chen, Dong-Yuan and Crest, Justin and Streichan, Sebastian J. and Bilder, David},
+  file = {/home/guillaume/.mozilla/firefox/14u1jeb7.default-1392277802592/zotero/storage/7PIYA6CG/Chen et al. - 2019 - Extracellular matrix stiffness cues junctional rem.pdf;/home/guillaume/.mozilla/firefox/14u1jeb7.default-1392277802592/zotero/storage/LPS26KHN/s41467-019-10874-x.html}
+}
+
 @preamble{ "\ifdefined\DeclarePrefChars\DeclarePrefChars{'’-}\else\fi " }
 


### PR DESCRIPTION
HDFStore doesn't support concurrent write (but does support concurrent read,  if I understand correctly). If a file is accessed both by the viewer and during the execution of the `record` method, it might produced the exception bellow;

```python-traceback
HDF5ExtError: HDF5 error back trace

  File "H5F.c", line 509, in H5Fopen
    unable to open file
  File "H5Fint.c", line 1567, in H5F_open
    unable to lock the file
  File "H5FD.c", line 1640, in H5FD_lock
    driver lock request failed
  File "H5FDsec2.c", line 959, in H5FD_sec2_lock
    unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'

End of HDF5 error back trace

Unable to open/create file '/data/Simulations/test_contractility_speed/1.005_constriction_0.1_radialtension.hf5'
```

The file was uselessly opened in append mode in the` __init__` of `HistoryHdf5` so I changed that, hopefully the bug won't happen again.
