### PR TITLE
fix for #185 - invagination bug from 0.5 to 0.7

### DIFF
--- a/tyssue/behaviors/sheet/actions.py
+++ b/tyssue/behaviors/sheet/actions.py
@@ -342,4 +342,4 @@ def relax(sheet, face, relax_decrease, relax_col="contractility"):
         divide=True,
         bound=(initial_contractility / 2),
     )
-    increase(sheet, "face", face, relax_decrease, "prefered_area", True, bound=(initial_prefered_area * 1.8))
+    increase(sheet, "face", face, relax_decrease, "prefered_area", True, bound=(initial_prefered_area * 2))

--- a/tyssue/behaviors/sheet/actions.py
+++ b/tyssue/behaviors/sheet/actions.py
@@ -332,6 +332,7 @@ def relax(sheet, face, relax_decrease, relax_col="contractility"):
 
     warnings.warn("deprecated, use decrease function")
     initial_contractility = 1.12
+    initial_prefered_area = 28
     decrease(
         sheet,
         "face",
@@ -341,4 +342,4 @@ def relax(sheet, face, relax_decrease, relax_col="contractility"):
         divide=True,
         bound=(initial_contractility / 2),
     )
-    increase(sheet, "face", face, relax_decrease, "prefered_area", True, bound=(initial_contractility / 2))
+    increase(sheet, "face", face, relax_decrease, "prefered_area", True, bound=(initial_prefered_area * 1.8))


### PR DESCRIPTION
(Accidentally created the pull request for my fork... instead of main)

`relax()` in 0.5.0 actions.py executes :
```
    initial_contractility = 1.12
    new_contractility = (
        sheet.face_df.loc[face, contraction_column] / contractility_decrease
    )
    if new_contractility >= (initial_contractility / 2):
        sheet.face_df.loc[face, contraction_column] = new_contractility
        sheet.face_df.loc[face, "prefered_area"] *= contractility_decrease
```

This was wrongly ported at some point when relax() was deprecated, calling only decrease() for the contractility with the bound but not applying the bound to the call of increase() for prefered_area:
```
    initial_contractility = 1.12
    decrease(
        sheet,
        "face",
        face,
        relax_decrease,
        col=relax_col,
        divide=True,
        bound=(initial_contractility / 2),
    )
    increase(sheet, "face", face, relax_decrease, "prefered_area", True)
```