### PR TITLE
Neighbour exchanges in delamination

### DIFF
--- a/tests/behaviors/test_sheet_events.py
+++ b/tests/behaviors/test_sheet_events.py
@@ -167,7 +167,7 @@ def test_execute_apoptosis():
     manager.update()
     next_nbsides = sheet.face_df.loc[sheet.idx_lookup(face_id, "face"), "num_sides"]
     i = 1
-    while next_nbsides > 4:
+    while next_nbsides > 3:
         assert next_nbsides == initial_nbsides - i
         assert len(manager.current) > 0
         i = i + 1

--- a/tyssue/behaviors/sheet/delamination_events.py
+++ b/tyssue/behaviors/sheet/delamination_events.py
@@ -130,7 +130,10 @@ def exchange_neighbour(sheet, manager, **kwargs):
     Executes neighbour exchanges for a face:
     1) if face_df[face, 'try_collapse_edge'] is True, collapse that face's shortest edge into a vert
     2) if face_df[face, 'try_expand_vert'] is True, expand that face's highest-order vert into an edge
-
+    
+    If either or both was successful:
+    1) Stores index of the new vert in face_df[face, 'edge_collapsed']
+    2) Stores index of the new edge in face_df[face, 'vert_expanded']
     
     Parameters
     ----------

--- a/tyssue/behaviors/sheet/delamination_events.py
+++ b/tyssue/behaviors/sheet/delamination_events.py
@@ -12,6 +12,8 @@ from ...utils.decorators import face_lookup
 from .actions import increase
 from .actions import ab_pull
 from .basic_events import contraction
+from ...topology.base_topology import collapse_edge
+from ...topology.sheet_topology import split_vert
 
 
 default_constriction_spec = {
@@ -122,7 +124,122 @@ def constriction(sheet, manager, **kwargs):
                 constriction_spec.update({"current_traction": current_traction})
 
     manager.append(constriction, **constriction_spec)
+    
+def exchange_neighbour(sheet, manager, **kwargs):
+    """
+    Executes neighbour exchanges for a face:
+    1) if face_df[face, 'try_collapse_edge'] is True, collapse that face's shortest edge into a vert
+    2) if face_df[face, 'try_expand_vert'] is True, expand that face's highest-order vert into an edge
 
+    
+    Parameters
+    ----------
+    sheet : a :class:`tyssue.sheet` object
+    manager : a :class:`tyssue.events.EventManager` object
+    **kwargs : parameters for the event, indices:
+        face_id: id of the face being checked for exchange events
+        critical_area: optional, default 1e-2, events are only executes if face area larger than this
+        minimum_edges: optional, default 3, edge will not be collapsed if face with fewer sides would result
+        maximum_edges: optional, default 10, vert will not be expanded if face with more sides would result
+        verbose: optional, default False, print log messages if True
+    """
+    exchange_spec = {
+        "face_id": -1,
+        "critical_area": 1e-2,
+        "minimum_edges": 3,
+        "maximum_edges": 10
+    }
+    exchange_spec.update(**kwargs)
+    verbose = exchange_spec.get("verbose", False)
+    
+    face_o = exchange_spec["face_id"]
+    if len(sheet.face_df[sheet.face_df["face_o"]==face_o])!=1:
+        if verbose:
+            if sheet.face_df[sheet.face_df["face_o"]==face_o].empty:
+                print(f"No face with original ID {face_o} exists.")
+            else:
+                print(f"More than one face with original ID {face_o} exists.")
+        return
+
+    face = sheet.face_df[sheet.face_df["face_o"]==face_o].index[0]
+    
+    do_collapse = sheet.face_df.loc[face,'try_collapse_edge']
+    do_expand = sheet.face_df.loc[face,'try_expand_vert']
+    if verbose and (do_collapse or do_expand):
+        print(f"neighbour exchange triggered for face {face}, "
+              f"originally {face_o}: collapse? {do_collapse} "
+              f"expand? {do_expand} ",end="\r")
+    
+    if (
+        do_collapse and 
+        sheet.face_df.loc[face].area > exchange_spec["critical_area"]
+    ):
+        #attempt to collapse the face's shortest edge
+        e_collapsilling = sheet.edge_df[
+            sheet.edge_df["face"]==face 
+        ]["length"].idxmin()
+        #check first: does this face, and the one opposite that edge have enough sides (>3)?
+        if verbose:
+            print(f"checking conditions for edge {e_collapsilling}, "
+                  f"face: {face}, originally {face_o} ",end="\r")
+        if sheet.face_df.loc[face].num_sides > exchange_spec["minimum_edges"]:
+            opposite_face = sheet.edge_df.loc[
+                sheet.edge_df.loc[e_collapsilling].opposite
+            ].face
+            
+            if sheet.face_df.loc[
+                opposite_face
+            ].num_sides > exchange_spec["minimum_edges"]:
+                if verbose:
+                    print(f"collapsing edge {e_collapsilling} (face {face})  ",
+                          end="\r")
+                remain_vert = collapse_edge(
+                    sheet, 
+                    e_collapsilling, 
+                    reindex=True,
+                    allow_two_sided=True
+                )
+                sheet.face_df.at[
+                    face,"edge_collapsed"
+                ] = sheet.vert_df.loc[remain_vert,"srce_o"]
+                sheet.face_df.at[
+                    opposite_face,"edge_collapsed"
+                ] = sheet.vert_df.loc[remain_vert,"srce_o"]
+            elif verbose:
+                print(f"could not collapse edge {e_collapsilling} "
+                      f"(face {face})  ",end="\r")
+            
+    if do_expand and sheet.face_df.loc[face].area > exchange_spec["critical_area"]:
+        #attempt to expand the face's highest-order vertex
+        #this works as if the cell pulled itself away from the rosette,
+        #creating a new edge between it and the rosette
+        verts = sheet.edge_df[sheet.edge_df["face"]==face]["srce"]
+        v_expandilling = sheet.edge_df.srce.value_counts().loc[verts].idxmax()
+        
+        #now check if the rearrangement meets the criteria for this vertex
+        # - is the vertex actually a rosette (more than tricellular)?
+        # - does this create a face with too many sides?
+        # nesting two if-clauses avoids calculating the second condition if the first fails
+        if (len( sheet.edge_df[ sheet.edge_df["srce"]==v_expandilling ] ) > 3):
+            neighbors_v_expandilling = sheet.get_neighbors(face).intersection(
+                sheet.edge_df[
+                    sheet.edge_df["trgt"]==v_expandilling
+                ]["face"].values
+            )
+            
+            if all(
+                len(sheet.edge_df.query(f"face == {nf}")) < exchange_spec[
+                    "maximum_edges"] for nf in neighbors_v_expandilling
+            ):
+                if verbose:
+                    print(f"splitting vert {v_expandilling} (face {face})  ",end="\r")
+                new_edges = split_vert(sheet, v_expandilling, face=face, multiplier=1.5, reindex=True, recenter=True)
+                #the fact that the vert was expanded needs to be stored
+                #for the two cells that are affected, i.e. the ones
+                #bordering the new edge
+                for e in new_edges:
+                    sheet.face_df.at[sheet.edge_df.loc[e]["face"],"vert_expanded"] = sheet.edge_df.loc[e,"edge_o"]
+    manager.append(exchange_neighbour, **exchange_spec)
 
 def _neighbor_contractile_increase(neighbor, constriction_spec):
 

--- a/tyssue/behaviors/sheet/delamination_events.py
+++ b/tyssue/behaviors/sheet/delamination_events.py
@@ -124,7 +124,7 @@ def constriction(sheet, manager, **kwargs):
                 constriction_spec.update({"current_traction": current_traction})
 
     manager.append(constriction, **constriction_spec)
-    
+
 def exchange_neighbour(sheet, manager, **kwargs):
     """
     Executes neighbour exchanges for a face:
@@ -174,12 +174,12 @@ def exchange_neighbour(sheet, manager, **kwargs):
               f"expand? {do_expand} ",end="\r")
     
     if (
-        do_collapse and 
+        do_collapse and
         sheet.face_df.loc[face].area > exchange_spec["critical_area"]
     ):
         #attempt to collapse the face's shortest edge
         e_collapsilling = sheet.edge_df[
-            sheet.edge_df["face"]==face 
+            sheet.edge_df["face"]==face
         ]["length"].idxmin()
         #check first: does this face, and the one opposite that edge have enough sides (>3)?
         if verbose:
@@ -197,8 +197,8 @@ def exchange_neighbour(sheet, manager, **kwargs):
                     print(f"collapsing edge {e_collapsilling} (face {face})  ",
                           end="\r")
                 remain_vert = collapse_edge(
-                    sheet, 
-                    e_collapsilling, 
+                    sheet,
+                    e_collapsilling,
                     reindex=True,
                     allow_two_sided=True
                 )

--- a/tyssue/topology/base_topology.py
+++ b/tyssue/topology/base_topology.py
@@ -230,7 +230,7 @@ def collapse_edge(sheet, edge, reindex=True, allow_two_sided=False):
 
     If `reindex` is `True` (the default), resets indexes and topology data.
     The edge is collapsed on the smaller of the srce, trgt indexes (to minimize reindexing impact)
-    
+
     Returns the index of the collapsed edge's remaining vertex (its srce)
 
     """

--- a/tyssue/topology/sheet_topology.py
+++ b/tyssue/topology/sheet_topology.py
@@ -20,6 +20,10 @@ def split_vert(
     """Splits a vertex towards the center of the face.
 
     This operation removes the  face `face` from the neighborhood of the vertex.
+    
+    Returns a list of the new edge's indices in edge_df. This should be two:
+        the edge with vert as the srce and the newly created vertex as the trgt
+        and the reverse edge with vert as the trgt and the new one as the srce
     """
     # Get the value for the length of the new edge
     if epsilon is None:
@@ -42,14 +46,17 @@ def split_vert(
     ]
 
     base_split_vert(sheet, vert, face, connected, epsilon, recenter)
-    for face_ in connected["face"]:
-        close_face(sheet, face_)
+    new_edges = []
+    for face_ in connected["face"].unique():
+        new_edge = close_face(sheet, face_)
+        if new_edge != None:
+            new_edges.append(new_edge)
 
     if reindex:
         sheet.reset_index()
         sheet.reset_topo()
 
-    return 0
+    return new_edges
 
 
 def type1_transition(sheet, edge01, *, remove_tri_faces=True, multiplier=1.5):

--- a/tyssue/topology/sheet_topology.py
+++ b/tyssue/topology/sheet_topology.py
@@ -20,7 +20,7 @@ def split_vert(
     """Splits a vertex towards the center of the face.
 
     This operation removes the  face `face` from the neighborhood of the vertex.
-    
+
     Returns a list of the new edge's indices in edge_df. This should be two:
         the edge with vert as the srce and the newly created vertex as the trgt
         and the reverse edge with vert as the trgt and the new one as the srce
@@ -49,7 +49,7 @@ def split_vert(
     new_edges = []
     for face_ in connected["face"].unique():
         new_edge = close_face(sheet, face_)
-        if new_edge != None:
+        if new_edge is not None:
             new_edges.append(new_edge)
 
     if reindex:


### PR DESCRIPTION
Hi Guillaume! I've finally found time to put together the modifications that I made to tyssue for my postdoc, and to submit the stuff that you might be interested to take over. I'm creating one branch for each "feature" that I added (and one with miscellaneous stuff like more detailed function descriptions). For now there's just this one and the misc_fixes branch on my fork, but I will hopefully find time next week to do the remaining two.

The changes on this branch implement a neighbour_exchanges event that allows simulations to have faces undergoing "partial" neighbour exchanges rather than stereotyped T1-transitions. I implemented this because in our model system (Chironomus riparius), mesodermal cells fluidly shift past each other, and only sometimes (by coincidence) these neighbour rearrangements are equivalent to full T1-transitions. I also added return values to all the topological change functions to make tracking, analysis and visualisations easier.

I'm creating the PR here to notify you, but I might end up stumbling upon more stuff that should go into this branch as well. I'll let you know when I think I'm done!

Feel free to discard anything you're not too happy with, or let me know any changes you'd like me to make. I'm also of course happy to answer any questions about why I did stuff the way I did, or to provide the modifications to the DamCB/invagination module that make use of this new functionality.