### PR TITLE
Update history.py

### DIFF
--- a/tyssue/core/history.py
+++ b/tyssue/core/history.py
@@ -328,6 +328,10 @@ class HistoryHdf5(History):
                             )
                         )
                         break
+        
+        with pd.HDFStore(self.hf5file, "r") as file:
+            self._time_stamps = file.select("vert", columns=["time"])["time"].unique()
+
         if sheet is None:
             last = self.time_stamps[-1]
             with pd.HDFStore(self.hf5file, "r") as file:
@@ -368,9 +372,7 @@ class HistoryHdf5(History):
 
     @property
     def time_stamps(self, element="vert"):
-        with pd.HDFStore(self.hf5file, "r") as file:
-            times = file.select(element, columns=["time"])["time"].unique()
-        return times
+        return self._time_stamps
 
     def record(self, time_stamp=None, sheet=None):
         """Appends a copy of the sheet datasets to the history HDF file.


### PR DESCRIPTION
> Added the self.time_stamps() method code for HistoryHdf5 class into the __init__() method so that time_stamps are only calculated once as self._time_stamps
> Edited self.time_stamps() method to return self._time_stamps
> Greatly improves efficiency of retrieve() method as time_stamps is not computed each time a new time-point is loaded.